### PR TITLE
Redesign as executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,4 +18,4 @@ jobs:
                 command: mvn test
             - run:
                 name: Package
-                command: package -DskipTests=true
+                command: mvn package -DskipTests=true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,37 +1,21 @@
 version: 2
 jobs:
-  build:
-    docker:
-      - image: circleci/openjdk:8-jdk
-    working_directory: ~/repo
+    build:
+        docker:
+            - image: circleci/openjdk:8-jdk
+        working_directory: ~/repo
 
-    environment:
-      MAVEN_OPTS: -Xmx3200m
+        environment:
+            MAVEN_OPTS: -Xmx3200m
 
-    steps:
-      - checkout
-      - run: mvn clean compile
-
-  test:
-    docker:
-      - image: circleci/openjdk:8-jdk
-    working_directory: ~/repo
-
-    environment:
-      MAVEN_OPTS: -Xmx3200m
-
-    steps:
-      - checkout
-      - run: mvn test
-      
-  deploy:
-    docker:
-      - image: circleci/openjdk:8-jdk
-    working_directory: ~/repo
-
-    environment:
-      MAVEN_OPTS: -Xmx3200m
-
-    steps:
-      - checkout
-      - run: mvn package -DskipTests=true
+        steps:
+            - checkout
+            - run: 
+                name: Compile
+                command: mvn clean compile
+            - run:
+                name: Test
+                command: mvn test
+            - run:
+                name: Package
+                command: package -DskipTests=true

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # exclutor
-Java executor service which support exclusive runnable, that block others till finished
+
+Implementation of exclusive-able asynchronous process
+
+example case:
+we need multiple asynchronous process to read data from database,
+but only one asynchronouse process for write data to database
+and the next read process will on hold till the write process finish.
+
+[![CircleCI](https://circleci.com/gh/kassle/exclutor/tree/master.svg?style=svg)](https://circleci.com/gh/kassle/exclutor/tree/master)
+
+## Usage:
+
+```java
+String scope = "db.table.users";
+Executor executor = ExclusiveExecutorFactory.create(Runtime.getRuntime().availableProcessors());
+executor.execute(new AbstractExclusiveRunnable(scope, true) {
+    @Override
+    public void run() {
+        // insert to database
+    }
+});
+executor.execute(new AbstractExclusiveRunnable(scope, false) {
+    @Override
+    public void run() {
+        // select from database
+    }
+});
+```

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>easymock</groupId>
+            <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
-            <version>2.0</version>
+            <version>4.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/krybrig/exclutor/AbstractExclusiveRunnable.java
+++ b/src/main/java/org/krybrig/exclutor/AbstractExclusiveRunnable.java
@@ -1,0 +1,27 @@
+package org.krybrig.exclutor;
+
+/**
+ *
+ * @author kassle
+ */
+public abstract class AbstractExclusiveRunnable implements ExclusiveRunnable {
+    private final String scope;
+    private final boolean exclusive;
+
+    public AbstractExclusiveRunnable(String scope, boolean exclusive) {
+        this.scope = scope;
+        this.exclusive = exclusive;
+    }
+
+    @Override
+    public String getScope() {
+        return scope;
+    }
+
+    @Override
+    public boolean isExclusive() {
+        return exclusive;
+    }
+    
+    
+}

--- a/src/main/java/org/krybrig/exclutor/ExclusiveExecutorFactory.java
+++ b/src/main/java/org/krybrig/exclutor/ExclusiveExecutorFactory.java
@@ -1,21 +1,32 @@
 package org.krybrig.exclutor;
 
-import java.util.concurrent.ExecutorService;
+import java.util.Queue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
 import org.krybrig.exclutor.internal.ExclusiveExecutor;
+import org.krybrig.exclutor.internal.ExclusiveWorkerFactory;
+import org.krybrig.exclutor.internal.ExclusiveWorkerFactoryImpl;
+import org.krybrig.exclutor.internal.LockBox;
+import org.krybrig.exclutor.internal.LockBoxImpl;
+import org.krybrig.exclutor.internal.ThreadPool;
+import org.krybrig.exclutor.internal.ThreadPoolImpl;
 
 /**
  *
  * @author kassle
  */
 public class ExclusiveExecutorFactory {
-    public static ExecutorService create(int corePoolSize, ThreadFactory threadFactory) {
-        return new ExclusiveExecutor(
-                corePoolSize, corePoolSize,
-                0, TimeUnit.MILLISECONDS,
-                new LinkedBlockingQueue<>(),
-                threadFactory);
+    public static Executor create(int maxThread) {
+        return create(maxThread, Executors.defaultThreadFactory(), new LinkedBlockingQueue<>());
+    }
+    
+    public static Executor create(int maxThread, ThreadFactory threadFactory, Queue<Runnable> queue) {
+        LockBox lockBox = new LockBoxImpl();
+        ExclusiveWorkerFactory workerFactory = new ExclusiveWorkerFactoryImpl(queue, lockBox);
+        ThreadPool threadPool = new ThreadPoolImpl(maxThread, workerFactory, threadFactory);
+        
+        return new ExclusiveExecutor(threadPool, queue);
     }
 }

--- a/src/main/java/org/krybrig/exclutor/ExclusiveExecutorFactory.java
+++ b/src/main/java/org/krybrig/exclutor/ExclusiveExecutorFactory.java
@@ -9,15 +9,44 @@ import org.krybrig.exclutor.internal.ExclusiveExecutor;
 import org.krybrig.exclutor.internal.ThreadPoolFactory;
 
 /**
- *
+ * <h1>Exclusive Executor Factory</h1>
+ * Factory to create exclusive executor instance
  * @author kassle
  */
 public class ExclusiveExecutorFactory {
+
+    /**
+     * Create new ExclusiveExecutor instance with default ThreadFactory and Queue
+     * @param maxThread maximum number of running thread
+     * @throws IllegalArgumentException when maxThread is zero or lower
+     * @return new ExclusiveExecutor instance
+     */
     public static Executor create(int maxThread) {
         return create(maxThread, Executors.defaultThreadFactory(), new LinkedBlockingQueue<>());
     }
-    
-    public static Executor create(int maxThread, ThreadFactory threadFactory, Queue<Runnable> queue) {        
+
+    /**
+     * Create new ExclusiveExecutor instance with default ThreadFactory and Queue
+     * @param maxThread maximum number of running thread
+     * @param threadFactory An object that creates new threads on demand
+     * @param queue the queue to use for holding tasks before they are executed
+     * @throws IllegalArgumentException when maxThread is zero or lower
+     * @throws NullPointerException when threadFactory or queue is null
+     * @return new ExclusiveExecutor instance
+     */
+    public static Executor create(int maxThread, ThreadFactory threadFactory, Queue<Runnable> queue) {
+        if (maxThread <= 0) {
+            throw new IllegalArgumentException("maxThread should be > 0");
+        }
+        
+        if (threadFactory == null) {
+            throw new NullPointerException("ThreadFactory should not null");
+        }
+        
+        if (queue == null) {
+            throw new NullPointerException("Queue should not null");
+        }
+
         return new ExclusiveExecutor(
                 ThreadPoolFactory.create(maxThread, threadFactory, queue),
                 queue);

--- a/src/main/java/org/krybrig/exclutor/ExclusiveExecutorFactory.java
+++ b/src/main/java/org/krybrig/exclutor/ExclusiveExecutorFactory.java
@@ -6,12 +6,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import org.krybrig.exclutor.internal.ExclusiveExecutor;
-import org.krybrig.exclutor.internal.ExclusiveWorkerFactory;
-import org.krybrig.exclutor.internal.ExclusiveWorkerFactoryImpl;
-import org.krybrig.exclutor.internal.LockBox;
-import org.krybrig.exclutor.internal.LockBoxImpl;
-import org.krybrig.exclutor.internal.ThreadPool;
-import org.krybrig.exclutor.internal.ThreadPoolImpl;
+import org.krybrig.exclutor.internal.ThreadPoolFactory;
 
 /**
  *
@@ -22,11 +17,9 @@ public class ExclusiveExecutorFactory {
         return create(maxThread, Executors.defaultThreadFactory(), new LinkedBlockingQueue<>());
     }
     
-    public static Executor create(int maxThread, ThreadFactory threadFactory, Queue<Runnable> queue) {
-        LockBox lockBox = new LockBoxImpl();
-        ExclusiveWorkerFactory workerFactory = new ExclusiveWorkerFactoryImpl(queue, lockBox);
-        ThreadPool threadPool = new ThreadPoolImpl(maxThread, workerFactory, threadFactory);
-        
-        return new ExclusiveExecutor(threadPool, queue);
+    public static Executor create(int maxThread, ThreadFactory threadFactory, Queue<Runnable> queue) {        
+        return new ExclusiveExecutor(
+                ThreadPoolFactory.create(maxThread, threadFactory, queue),
+                queue);
     }
 }

--- a/src/main/java/org/krybrig/exclutor/ExclusiveRunnable.java
+++ b/src/main/java/org/krybrig/exclutor/ExclusiveRunnable.java
@@ -6,7 +6,7 @@ package org.krybrig.exclutor;
  */
 public interface ExclusiveRunnable extends Runnable {
     
-    abstract public String getScope();
+    String getScope();
 
     boolean isExclusive();
 }

--- a/src/main/java/org/krybrig/exclutor/internal/DummyLock.java
+++ b/src/main/java/org/krybrig/exclutor/internal/DummyLock.java
@@ -8,7 +8,7 @@ import java.util.concurrent.locks.Lock;
  *
  * @author kassle
  */
-public class DummyLock implements Lock {
+class DummyLock implements Lock {
 
     @Override
     public void lock() {

--- a/src/main/java/org/krybrig/exclutor/internal/ExclusiveExecutor.java
+++ b/src/main/java/org/krybrig/exclutor/internal/ExclusiveExecutor.java
@@ -1,62 +1,31 @@
 package org.krybrig.exclutor.internal;
 
 import java.util.Queue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Executor;
 
 /**
  *
  * @author kassle
  */
-public class ExclusiveExecutor extends ThreadPoolExecutor {
+public class ExclusiveExecutor implements Executor {
+    private final ThreadPool pool;
     private final Queue<Runnable> queue;
-    private final ExclusiveWorkerFactory workerFactory;
-    
-    public ExclusiveExecutor(
-            int corePoolSize,
-            int maximumPoolSize,
-            long keepAliveTime,
-            TimeUnit unit,
-            BlockingQueue<Runnable> queue,
-            ThreadFactory threadFactory) {
-        
-        this(new ExclusiveWorkerFactoryImpl(queue, new LockBoxImpl()),
-                corePoolSize, maximumPoolSize, keepAliveTime, unit, queue, threadFactory);
-    }
 
-    public ExclusiveExecutor(
-            ExclusiveWorkerFactory workerFactory,
-            int corePoolSize,
-            int maximumPoolSize,
-            long keepAliveTime,
-            TimeUnit unit,
-            BlockingQueue<Runnable> queue,
-            ThreadFactory threadFactory) {
-        
-        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, queue, threadFactory);
-        
-        this.workerFactory = workerFactory;
+    public ExclusiveExecutor(ThreadPool pool, Queue<Runnable> queue) {
+        this.pool = pool;
         this.queue = queue;
-    }
+    }    
 
     @Override
-    public Future<?> submit(Runnable task) {
+    public void execute(Runnable task) {
         if (task == null) {
-            throw new NullPointerException();
+            throw new NullPointerException("Task should not null");
         }
-        
+
         synchronized (queue) {
             queue.offer(task);
         }
-        
-        return super.submit(workerFactory.create(new WorkerListener() {
-            @Override
-            public void onFinish() {
-            }
-        }));
+
+        pool.onTaskAdded();
     }
 }

--- a/src/main/java/org/krybrig/exclutor/internal/ExclusiveWorker.java
+++ b/src/main/java/org/krybrig/exclutor/internal/ExclusiveWorker.java
@@ -12,10 +12,12 @@ public class ExclusiveWorker implements Runnable {
 
     private final Queue<Runnable> queue;
     private final LockBox lockBox;
+    private final WorkerListener listener;
 
-    ExclusiveWorker(Queue<Runnable> queue, LockBox lockBox) {
+    ExclusiveWorker(Queue<Runnable> queue, LockBox lockBox, WorkerListener listener) {
         this.queue = queue;
         this.lockBox = lockBox;
+        this.listener = listener;
     }
 
     @Override
@@ -29,6 +31,7 @@ public class ExclusiveWorker implements Runnable {
                 lock = getLock(runnable);
                 lock.lock();
             } else {
+                listener.onFinish();
                 return;
             }
         }
@@ -43,6 +46,7 @@ public class ExclusiveWorker implements Runnable {
             if (isExclusive(runnable)) {
                 lock.unlock();
             }
+            listener.onFinish();
         }
     }
 

--- a/src/main/java/org/krybrig/exclutor/internal/ExclusiveWorker.java
+++ b/src/main/java/org/krybrig/exclutor/internal/ExclusiveWorker.java
@@ -8,7 +8,7 @@ import org.krybrig.exclutor.ExclusiveRunnable;
  *
  * @author kassle
  */
-public class ExclusiveWorker implements Runnable {
+class ExclusiveWorker implements Runnable {
 
     private final Queue<Runnable> queue;
     private final LockBox lockBox;

--- a/src/main/java/org/krybrig/exclutor/internal/ExclusiveWorkerFactory.java
+++ b/src/main/java/org/krybrig/exclutor/internal/ExclusiveWorkerFactory.java
@@ -4,6 +4,6 @@ package org.krybrig.exclutor.internal;
  *
  * @author kassle
  */
-public interface ExclusiveWorkerFactory {
+interface ExclusiveWorkerFactory {
     Runnable create(WorkerListener listener);
 }

--- a/src/main/java/org/krybrig/exclutor/internal/ExclusiveWorkerFactory.java
+++ b/src/main/java/org/krybrig/exclutor/internal/ExclusiveWorkerFactory.java
@@ -1,11 +1,9 @@
 package org.krybrig.exclutor.internal;
 
-import java.util.Queue;
-
 /**
  *
  * @author kassle
  */
 public interface ExclusiveWorkerFactory {
-    Runnable create(Queue<Runnable> queue, LockBox lockBox);
+    Runnable create(WorkerListener listener);
 }

--- a/src/main/java/org/krybrig/exclutor/internal/ExclusiveWorkerFactoryImpl.java
+++ b/src/main/java/org/krybrig/exclutor/internal/ExclusiveWorkerFactoryImpl.java
@@ -7,14 +7,21 @@ import java.util.Queue;
  * @author kassle
  */
 public class ExclusiveWorkerFactoryImpl implements ExclusiveWorkerFactory {
+    private final Queue<Runnable> queue;
+    private final LockBox lockBox;
+
+    ExclusiveWorkerFactoryImpl(Queue<Runnable> queue, LockBox lockBox) {
+        if (queue == null || lockBox == null) {
+            throw new NullPointerException("Queue, LockBox and Listener should not null");
+        }
+        
+        this.queue = queue;
+        this.lockBox = lockBox;
+    }
     
     @Override
-    public Runnable create(Queue<Runnable> queue, LockBox lockBox) {
-        if (queue != null && lockBox != null) {
-            return new ExclusiveWorker(queue, lockBox);
-        } else {
-            throw new NullPointerException("Queue & LockBox should not null");
-        }
+    public Runnable create(WorkerListener listener) {
+        return new ExclusiveWorker(queue, lockBox, listener);
     }
     
 }

--- a/src/main/java/org/krybrig/exclutor/internal/ExclusiveWorkerFactoryImpl.java
+++ b/src/main/java/org/krybrig/exclutor/internal/ExclusiveWorkerFactoryImpl.java
@@ -10,7 +10,7 @@ public class ExclusiveWorkerFactoryImpl implements ExclusiveWorkerFactory {
     private final Queue<Runnable> queue;
     private final LockBox lockBox;
 
-    ExclusiveWorkerFactoryImpl(Queue<Runnable> queue, LockBox lockBox) {
+    public ExclusiveWorkerFactoryImpl(Queue<Runnable> queue, LockBox lockBox) {
         if (queue == null || lockBox == null) {
             throw new NullPointerException("Queue, LockBox and Listener should not null");
         }

--- a/src/main/java/org/krybrig/exclutor/internal/ExclusiveWorkerFactoryImpl.java
+++ b/src/main/java/org/krybrig/exclutor/internal/ExclusiveWorkerFactoryImpl.java
@@ -6,13 +6,13 @@ import java.util.Queue;
  *
  * @author kassle
  */
-public class ExclusiveWorkerFactoryImpl implements ExclusiveWorkerFactory {
+class ExclusiveWorkerFactoryImpl implements ExclusiveWorkerFactory {
     private final Queue<Runnable> queue;
     private final LockBox lockBox;
-
-    public ExclusiveWorkerFactoryImpl(Queue<Runnable> queue, LockBox lockBox) {
+    
+    ExclusiveWorkerFactoryImpl(Queue<Runnable> queue, LockBox lockBox) {
         if (queue == null || lockBox == null) {
-            throw new NullPointerException("Queue, LockBox and Listener should not null");
+            throw new NullPointerException("Queue & LockBox should not null");
         }
         
         this.queue = queue;

--- a/src/main/java/org/krybrig/exclutor/internal/LockBox.java
+++ b/src/main/java/org/krybrig/exclutor/internal/LockBox.java
@@ -6,6 +6,6 @@ import java.util.concurrent.locks.Lock;
  *
  * @author kassle
  */
-interface LockBox {
+public interface LockBox {
     Lock getLock(String scope);
 }

--- a/src/main/java/org/krybrig/exclutor/internal/LockBox.java
+++ b/src/main/java/org/krybrig/exclutor/internal/LockBox.java
@@ -6,6 +6,6 @@ import java.util.concurrent.locks.Lock;
  *
  * @author kassle
  */
-public interface LockBox {
+interface LockBox {
     Lock getLock(String scope);
 }

--- a/src/main/java/org/krybrig/exclutor/internal/LockBoxImpl.java
+++ b/src/main/java/org/krybrig/exclutor/internal/LockBoxImpl.java
@@ -9,7 +9,7 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * @author kassle
  */
-class LockBoxImpl implements LockBox {
+public class LockBoxImpl implements LockBox {
     private final Map<String, Lock> lockMap = new HashMap<>();
 
     @Override

--- a/src/main/java/org/krybrig/exclutor/internal/LockBoxImpl.java
+++ b/src/main/java/org/krybrig/exclutor/internal/LockBoxImpl.java
@@ -9,7 +9,7 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * @author kassle
  */
-public class LockBoxImpl implements LockBox {
+class LockBoxImpl implements LockBox {
     private final Map<String, Lock> lockMap = new HashMap<>();
 
     @Override

--- a/src/main/java/org/krybrig/exclutor/internal/ThreadPool.java
+++ b/src/main/java/org/krybrig/exclutor/internal/ThreadPool.java
@@ -4,7 +4,7 @@ package org.krybrig.exclutor.internal;
  *
  * @author kassle
  */
-public interface ThreadPool {
+interface ThreadPool {
     void onTaskAdded();
     int getRemainingTask();
     int getThreadNumber();

--- a/src/main/java/org/krybrig/exclutor/internal/ThreadPool.java
+++ b/src/main/java/org/krybrig/exclutor/internal/ThreadPool.java
@@ -1,0 +1,11 @@
+package org.krybrig.exclutor.internal;
+
+/**
+ *
+ * @author kassle
+ */
+public interface ThreadPool {
+    void onTaskAdded();
+    int getRemainingTask();
+    int getThreadNumber();
+}

--- a/src/main/java/org/krybrig/exclutor/internal/ThreadPoolFactory.java
+++ b/src/main/java/org/krybrig/exclutor/internal/ThreadPoolFactory.java
@@ -1,0 +1,20 @@
+package org.krybrig.exclutor.internal;
+
+import java.util.Queue;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ *
+ * @author kassle
+ */
+public class ThreadPoolFactory {
+    public static ThreadPool create(int maxThread, ThreadFactory threadFactory, Queue<Runnable> queue) {
+        LockBox lockBox = new LockBoxImpl();
+        ExclusiveWorkerFactory workerFactory = new ExclusiveWorkerFactoryImpl(queue, lockBox);
+        return create(maxThread, workerFactory, threadFactory);
+    }
+    
+    static ThreadPool create(int maxThread, ExclusiveWorkerFactory workerFactory, ThreadFactory threadFactory) {
+        return new ThreadPoolImpl(maxThread, workerFactory, threadFactory);
+    }
+}

--- a/src/main/java/org/krybrig/exclutor/internal/ThreadPoolImpl.java
+++ b/src/main/java/org/krybrig/exclutor/internal/ThreadPoolImpl.java
@@ -24,20 +24,13 @@ public class ThreadPoolImpl implements ThreadPool, WorkerListener {
 
     @Override
     public void onTaskAdded() {
-        synchronized (taskCounter) {
-            taskCounter.getAndIncrement();
-
-            synchronized (threadCounter) {
-                startNewThread();
-            }
-        }
+        taskCounter.getAndIncrement();
+        startNewThread();
     }
 
     @Override
     public int getRemainingTask() {
-        synchronized (taskCounter) {
-            return taskCounter.get();
-        }
+        return taskCounter.get();
     }
 
     @Override
@@ -51,19 +44,18 @@ public class ThreadPoolImpl implements ThreadPool, WorkerListener {
     public void onFinish() {
         synchronized (threadCounter) {
             threadCounter.getAndDecrement();
-
-            synchronized (taskCounter) {
-                startNewThread();
-            }
+            startNewThread();
         }
     }
 
     private void startNewThread() {
-        if (taskCounter.get() > 0 && threadCounter.get() < maxThread) {
-            Thread thread = threadFactory.newThread(workerFactory.create(this));
-            threadCounter.getAndIncrement();
-            taskCounter.getAndDecrement();
-            thread.start();
+        synchronized (threadCounter) {
+            if (taskCounter.get() > 0 && threadCounter.get() < maxThread) {
+                Thread thread = threadFactory.newThread(workerFactory.create(this));
+                threadCounter.getAndIncrement();
+                taskCounter.getAndDecrement();
+                thread.start();
+            }
         }
     }
 }

--- a/src/main/java/org/krybrig/exclutor/internal/ThreadPoolImpl.java
+++ b/src/main/java/org/krybrig/exclutor/internal/ThreadPoolImpl.java
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @author kassle
  */
-public class ThreadPoolImpl implements ThreadPool, WorkerListener {
+class ThreadPoolImpl implements ThreadPool, WorkerListener {
 
     private final int maxThread;
     private final ExclusiveWorkerFactory workerFactory;
@@ -16,7 +16,7 @@ public class ThreadPoolImpl implements ThreadPool, WorkerListener {
     private final AtomicInteger taskCounter = new AtomicInteger();
     private final AtomicInteger threadCounter = new AtomicInteger();
 
-    public ThreadPoolImpl(int maxThread, ExclusiveWorkerFactory workerFactory, ThreadFactory threadFactory) {
+    ThreadPoolImpl(int maxThread, ExclusiveWorkerFactory workerFactory, ThreadFactory threadFactory) {
         this.maxThread = maxThread;
         this.workerFactory = workerFactory;
         this.threadFactory = threadFactory;

--- a/src/main/java/org/krybrig/exclutor/internal/ThreadPoolImpl.java
+++ b/src/main/java/org/krybrig/exclutor/internal/ThreadPoolImpl.java
@@ -1,0 +1,69 @@
+package org.krybrig.exclutor.internal;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ *
+ * @author kassle
+ */
+public class ThreadPoolImpl implements ThreadPool, WorkerListener {
+
+    private final int maxThread;
+    private final ExclusiveWorkerFactory workerFactory;
+    private final ThreadFactory threadFactory;
+
+    private final AtomicInteger taskCounter = new AtomicInteger();
+    private final AtomicInteger threadCounter = new AtomicInteger();
+
+    public ThreadPoolImpl(int maxThread, ExclusiveWorkerFactory workerFactory, ThreadFactory threadFactory) {
+        this.maxThread = maxThread;
+        this.workerFactory = workerFactory;
+        this.threadFactory = threadFactory;
+    }
+
+    @Override
+    public void onTaskAdded() {
+        synchronized (taskCounter) {
+            taskCounter.getAndIncrement();
+
+            synchronized (threadCounter) {
+                startNewThread();
+            }
+        }
+    }
+
+    @Override
+    public int getRemainingTask() {
+        synchronized (taskCounter) {
+            return taskCounter.get();
+        }
+    }
+
+    @Override
+    public int getThreadNumber() {
+        synchronized (threadCounter) {
+            return threadCounter.get();
+        }
+    }
+
+    @Override
+    public void onFinish() {
+        synchronized (threadCounter) {
+            threadCounter.getAndDecrement();
+
+            synchronized (taskCounter) {
+                startNewThread();
+            }
+        }
+    }
+
+    private void startNewThread() {
+        if (taskCounter.get() > 0 && threadCounter.get() < maxThread) {
+            Thread thread = threadFactory.newThread(workerFactory.create(this));
+            threadCounter.getAndIncrement();
+            taskCounter.getAndDecrement();
+            thread.start();
+        }
+    }
+}

--- a/src/main/java/org/krybrig/exclutor/internal/WorkerListener.java
+++ b/src/main/java/org/krybrig/exclutor/internal/WorkerListener.java
@@ -4,6 +4,6 @@ package org.krybrig.exclutor.internal;
  *
  * @author kassle
  */
-public interface WorkerListener {
+interface WorkerListener {
     void onFinish();
 }

--- a/src/main/java/org/krybrig/exclutor/internal/WorkerListener.java
+++ b/src/main/java/org/krybrig/exclutor/internal/WorkerListener.java
@@ -1,0 +1,9 @@
+package org.krybrig.exclutor.internal;
+
+/**
+ *
+ * @author kassle
+ */
+public interface WorkerListener {
+    void onFinish();
+}

--- a/src/test/java/org/krybrig/exclutor/ExclusiveExecutorFactoryTest.java
+++ b/src/test/java/org/krybrig/exclutor/ExclusiveExecutorFactoryTest.java
@@ -25,4 +25,26 @@ public class ExclusiveExecutorFactoryTest {
         assertNotNull(executor2);
         assertNotSame(executor1, executor2);
     }
+    
+    @Test (expected = IllegalArgumentException.class)
+    public void zeroMaxThreadShouldThrowIllegalArgumentException() {
+        ExclusiveExecutorFactory.create(0);
+    }
+    
+    @Test (expected = IllegalArgumentException.class)
+    public void negativeMaxThreadShouldThrowIllegalArgumentException() {
+        ExclusiveExecutorFactory.create(-1);
+    }
+    
+    @Test (expected = NullPointerException.class)
+    public void nullThreadFactoryShouldThrowNullpointerException() {
+        Queue<Runnable> queue = EasyMock.createMock(Queue.class);
+        ExclusiveExecutorFactory.create(1, null, queue);
+    }
+    
+    @Test (expected = NullPointerException.class)
+    public void nullQueueShouldThrowNullpointerException() {
+        ThreadFactory threadFactory = EasyMock.createMock(ThreadFactory.class);
+        ExclusiveExecutorFactory.create(1, threadFactory, null);
+    }
 }

--- a/src/test/java/org/krybrig/exclutor/ExclusiveExecutorFactoryTest.java
+++ b/src/test/java/org/krybrig/exclutor/ExclusiveExecutorFactoryTest.java
@@ -1,6 +1,7 @@
 package org.krybrig.exclutor;
 
-import java.util.concurrent.ExecutorService;
+import java.util.Queue;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 import org.easymock.EasyMock;
 import org.junit.Test;
@@ -14,10 +15,11 @@ public class ExclusiveExecutorFactoryTest {
     
     @Test
     public void createShouldReturnNewObject() {
+        Queue<Runnable> queue = EasyMock.createMock(Queue.class);
         ThreadFactory threadFactory = EasyMock.createMock(ThreadFactory.class);
         
-        ExecutorService executor1 = ExclusiveExecutorFactory.create(1, threadFactory);
-        ExecutorService executor2 = ExclusiveExecutorFactory.create(1, threadFactory);
+        Executor executor1 = ExclusiveExecutorFactory.create(1, threadFactory, queue);
+        Executor executor2 = ExclusiveExecutorFactory.create(1, threadFactory, queue);
         
         assertNotNull(executor1);
         assertNotNull(executor2);

--- a/src/test/java/org/krybrig/exclutor/cases/MultiScopeTest.java
+++ b/src/test/java/org/krybrig/exclutor/cases/MultiScopeTest.java
@@ -32,9 +32,12 @@ public class MultiScopeTest {
         int grouping = 4;
         
         final List<Item> resultList = Collections.synchronizedList(new ArrayList<>());
+        long start = System.currentTimeMillis();
         for (int i = 1; i <= count; i++) {
             executor.execute(new ExclusiveRunnableImpl(i, segment, resultList, grouping));
         }
+        long finish = System.currentTimeMillis();
+        System.out.println("submit for " + count + " job finish in " + (finish - start));
         
         Thread.sleep(5000);
         

--- a/src/test/java/org/krybrig/exclutor/cases/MultiScopeTest.java
+++ b/src/test/java/org/krybrig/exclutor/cases/MultiScopeTest.java
@@ -3,6 +3,7 @@ package org.krybrig.exclutor.cases;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -17,27 +18,25 @@ import org.krybrig.exclutor.ExclusiveRunnable;
  * @author kassle
  */
 public class MultiScopeTest {
-    private ExecutorService executor;
+    private Executor executor;
     
     @Before
     public void setUp() {
-        executor = ExclusiveExecutorFactory.create(
-                Runtime.getRuntime().availableProcessors(),
-                Executors.defaultThreadFactory());
+        executor = ExclusiveExecutorFactory.create(Runtime.getRuntime().availableProcessors());
     }
     
     @Test
     public void exclusiveRunnableShouldBlockNextNonExclusiveRunnableWhenSameScope() throws InterruptedException {
-        int count = 1000000;
+        int count = 1000;
         int segment = 100;
         int grouping = 4;
         
         final List<Item> resultList = Collections.synchronizedList(new ArrayList<>());
         for (int i = 1; i <= count; i++) {
-            executor.submit(new ExclusiveRunnableImpl(i, segment, resultList, grouping));
+            executor.execute(new ExclusiveRunnableImpl(i, segment, resultList, grouping));
         }
-        executor.shutdown();
-        executor.awaitTermination(5, TimeUnit.SECONDS);
+        
+        Thread.sleep(5000);
         
         assertEquals(count, resultList.size());
         

--- a/src/test/java/org/krybrig/exclutor/cases/SingleScopeTest.java
+++ b/src/test/java/org/krybrig/exclutor/cases/SingleScopeTest.java
@@ -29,11 +29,13 @@ public class SingleScopeTest {
         int segment = 100;
         
         final List<Integer> resultList = Collections.synchronizedList(new ArrayList<>());
+        long start = System.currentTimeMillis();
         for (int i = 1; i <= count; i++) {
             executor.execute(new ExclusiveRunnableImpl(i, segment, resultList));
         }
+        long finish = System.currentTimeMillis();
+        System.out.println("submit for " + count + " job finish in " + (finish - start));
         
-        System.out.println("Waiting for completion");
         Thread.sleep(1000 * 5);
         
         assertEquals(count, resultList.size());

--- a/src/test/java/org/krybrig/exclutor/cases/SingleScopeTest.java
+++ b/src/test/java/org/krybrig/exclutor/cases/SingleScopeTest.java
@@ -3,8 +3,7 @@ package org.krybrig.exclutor.cases;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,26 +16,25 @@ import org.krybrig.exclutor.ExclusiveRunnable;
  * @author kassle
  */
 public class SingleScopeTest {
-    private ExecutorService executor;
+    private Executor executor;
     
     @Before
     public void setUp() {
-        executor = ExclusiveExecutorFactory.create(
-                Runtime.getRuntime().availableProcessors(),
-                Executors.defaultThreadFactory());
+        executor = ExclusiveExecutorFactory.create(Runtime.getRuntime().availableProcessors());
     }
     
     @Test
     public void exclusiveRunnableShouldBlockNextNonExclusiveRunnable() throws InterruptedException {
-        int count = 100000;
+        int count = 1000;
         int segment = 100;
         
         final List<Integer> resultList = Collections.synchronizedList(new ArrayList<>());
         for (int i = 1; i <= count; i++) {
-            executor.submit(new ExclusiveRunnableImpl(i, segment, resultList));
+            executor.execute(new ExclusiveRunnableImpl(i, segment, resultList));
         }
-        executor.shutdown();
-        executor.awaitTermination(5, TimeUnit.SECONDS);
+        
+        System.out.println("Waiting for completion");
+        Thread.sleep(1000 * 5);
         
         assertEquals(count, resultList.size());
         
@@ -78,7 +76,7 @@ public class SingleScopeTest {
         public void run() {
             if (isExclusive()) {
                 try {
-                    Thread.sleep(5);
+                    Thread.sleep(10);
                 } catch (InterruptedException ex) { }
             }
             resultList.add(id);

--- a/src/test/java/org/krybrig/exclutor/internal/ExclusiveExecutorTest.java
+++ b/src/test/java/org/krybrig/exclutor/internal/ExclusiveExecutorTest.java
@@ -1,9 +1,6 @@
 package org.krybrig.exclutor.internal;
 
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
+import java.util.Queue;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
@@ -14,44 +11,38 @@ import org.junit.Test;
  * @author kassle
  */
 public class ExclusiveExecutorTest {
-    private BlockingQueue<Runnable> queue;
-    private ExclusiveWorkerFactory workerFactory;
+    private Queue<Runnable> queue;
+    private ThreadPool pool;
+    
     private ExclusiveExecutor executor;
     
     @Before
     public void setUp() {
-        workerFactory = EasyMock.createMock(ExclusiveWorkerFactory.class);
-        queue = new LinkedBlockingQueue<>();
+        queue = EasyMock.createMock(Queue.class);
+        pool = EasyMock.createMock(ThreadPool.class);
         
-        executor = new ExclusiveExecutor(
-                workerFactory,
-                1, 1, 0, TimeUnit.MILLISECONDS,
-                queue,
-                Executors.defaultThreadFactory());
+        executor = new ExclusiveExecutor(pool, queue);
     }
-
+    
     @Test
-    public void executeShouldCreateWorkerAndPlaceRunnableToQueue() {
-        Runnable worker = EasyMock.createMock(Runnable.class);
-        worker.run();
-        EasyMock.replay(worker);
+    public void executeShouldAddToQueueAndCallThreadPoolTaskAdded() {
+        Runnable task = EasyMock.createMock(Runnable.class);
         
-        WorkerListener listener = EasyMock.createMock(WorkerListener.class);
-        EasyMock.expect(workerFactory.create(listener)).andReturn(worker);
-        EasyMock.replay(workerFactory);
+        EasyMock.expect(queue.offer(task)).andReturn(true);
+        pool.onTaskAdded();
+        EasyMock.replay(queue, pool);
         
-        Runnable runnable = EasyMock.createMock(Runnable.class);
+        executor.execute(task);
         
-        executor.submit(runnable);
-        
-        EasyMock.verify(workerFactory);
-        
-        Assert.assertEquals(1, queue.size());
-        Assert.assertSame(runnable, queue.peek());
+        EasyMock.verify(queue, pool);
     }
     
     @Test (expected = NullPointerException.class)
-    public void executeShouldThrowNullPointerWhenRunnableIsNull() {
+    public void executeShouldThrowNullPointerExceptionWhenTaskIsNull() {
+        EasyMock.replay(queue, pool);
+        
         executor.execute(null);
+        
+        EasyMock.verify(queue, pool);
     }
 }

--- a/src/test/java/org/krybrig/exclutor/internal/ExclusiveExecutorTest.java
+++ b/src/test/java/org/krybrig/exclutor/internal/ExclusiveExecutorTest.java
@@ -1,7 +1,6 @@
 package org.krybrig.exclutor.internal;
 
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -15,22 +14,19 @@ import org.junit.Test;
  * @author kassle
  */
 public class ExclusiveExecutorTest {
-    private LockBox lockBox;
     private BlockingQueue<Runnable> queue;
     private ExclusiveWorkerFactory workerFactory;
-    private ExecutorService executor;
+    private ExclusiveExecutor executor;
     
     @Before
     public void setUp() {
-        lockBox = EasyMock.createMock(LockBox.class);
         workerFactory = EasyMock.createMock(ExclusiveWorkerFactory.class);
         queue = new LinkedBlockingQueue<>();
         
         executor = new ExclusiveExecutor(
-                lockBox, workerFactory,
+                workerFactory,
                 1, 1, 0, TimeUnit.MILLISECONDS,
                 queue,
-                new LinkedBlockingQueue<>(),
                 Executors.defaultThreadFactory());
     }
 
@@ -40,7 +36,8 @@ public class ExclusiveExecutorTest {
         worker.run();
         EasyMock.replay(worker);
         
-        EasyMock.expect(workerFactory.create(queue, lockBox)).andReturn(worker);
+        WorkerListener listener = EasyMock.createMock(WorkerListener.class);
+        EasyMock.expect(workerFactory.create(listener)).andReturn(worker);
         EasyMock.replay(workerFactory);
         
         Runnable runnable = EasyMock.createMock(Runnable.class);

--- a/src/test/java/org/krybrig/exclutor/internal/ExclusiveWorkerFactoryImplTest.java
+++ b/src/test/java/org/krybrig/exclutor/internal/ExclusiveWorkerFactoryImplTest.java
@@ -13,18 +13,20 @@ import static org.junit.Assert.*;
 public class ExclusiveWorkerFactoryImplTest {
     private Queue<Runnable> queue;
     private LockBox lockBox;
+    private WorkerListener listener;
     private ExclusiveWorkerFactory factory;
     
     @Before
     public void setUp() {
         queue = EasyMock.createMock(Queue.class);
         lockBox = EasyMock.createMock(LockBox.class);
-        factory = new ExclusiveWorkerFactoryImpl();
+        listener = EasyMock.createMock(WorkerListener.class);
+        factory = new ExclusiveWorkerFactoryImpl(queue, lockBox);
     }
 
     @Test
     public void createShouldReturnWorker() {
-        Runnable worker = factory.create(queue, lockBox);
+        Runnable worker = factory.create(listener);
         
         assertNotNull(worker);
         assertEquals(true, worker instanceof ExclusiveWorker);
@@ -32,19 +34,19 @@ public class ExclusiveWorkerFactoryImplTest {
     
     @Test
     public void createShouldAlwaysReturnNewWorkerInstance() {
-        Runnable worker1 = factory.create(queue, lockBox);
-        Runnable worker2 = factory.create(queue, lockBox);
+        Runnable worker1 = factory.create(listener);
+        Runnable worker2 = factory.create(listener);
         
         assertNotSame(worker1, worker2);
     }
     
     @Test(expected = NullPointerException.class)
     public void createShouldThrowNullPointerWhenQueueIsNull() {
-        factory.create(null, lockBox);
+        new ExclusiveWorkerFactoryImpl(null, lockBox);
     }
     
     @Test(expected = NullPointerException.class)
     public void createShouldThrowNullPointerWhenLockBoxIsNull() {
-        factory.create(queue, null);
+        new ExclusiveWorkerFactoryImpl(queue, null);
     }
 }

--- a/src/test/java/org/krybrig/exclutor/internal/ExclusiveWorkerTest.java
+++ b/src/test/java/org/krybrig/exclutor/internal/ExclusiveWorkerTest.java
@@ -14,14 +14,16 @@ import org.krybrig.exclutor.ExclusiveRunnable;
 public class ExclusiveWorkerTest {
     private Queue<Runnable> queue;
     private LockBox lockBox;
+    private WorkerListener listener;
     private ExclusiveWorker worker;
     
     @Before
     public void setUp() {
         queue = EasyMock.createMock(Queue.class);
         lockBox = EasyMock.createMock(LockBox.class);
+        listener = EasyMock.createMock(WorkerListener.class);
         
-        worker = new ExclusiveWorker(queue, lockBox);
+        worker = new ExclusiveWorker(queue, lockBox, listener);
     }
 
     @Test
@@ -33,9 +35,13 @@ public class ExclusiveWorkerTest {
         EasyMock.expect(queue.poll()).andReturn(runnable);
         EasyMock.replay(queue);
         
+        listener.onFinish();
+        EasyMock.replay(listener);
+        
         worker.run();
         
         EasyMock.verify(runnable);
+        EasyMock.verify(listener);
     }
     
     @Test
@@ -43,9 +49,13 @@ public class ExclusiveWorkerTest {
         EasyMock.expect(queue.poll()).andReturn(null);
         EasyMock.replay(queue);
         
+        listener.onFinish();
+        EasyMock.replay(listener);
+        
         worker.run();
         
         EasyMock.verify(queue);
+        EasyMock.verify(listener);
     }
     
     @Test
@@ -68,10 +78,14 @@ public class ExclusiveWorkerTest {
         EasyMock.expect(queue.poll()).andReturn(runnable);
         EasyMock.replay(queue);
         
+        listener.onFinish();
+        EasyMock.replay(listener);
+        
         worker.run();
         
         EasyMock.verify(runnable);
         EasyMock.verify(lock);
+        EasyMock.verify(listener);
     }
     
     @Test 
@@ -104,10 +118,14 @@ public class ExclusiveWorkerTest {
         EasyMock.expect(queue.poll()).andReturn(runnable);
         EasyMock.replay(queue);
         
+        listener.onFinish();
+        EasyMock.replay(listener);
+        
         try {
             worker.run();
         } catch (RuntimeException ex) { }
         
         EasyMock.verify(lock);
+        EasyMock.verify(listener);
     }
 }

--- a/src/test/java/org/krybrig/exclutor/internal/ThreadPoolImplTest.java
+++ b/src/test/java/org/krybrig/exclutor/internal/ThreadPoolImplTest.java
@@ -1,0 +1,116 @@
+package org.krybrig.exclutor.internal;
+
+import java.util.concurrent.ThreadFactory;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author kassle
+ */
+public class ThreadPoolImplTest {
+    private int max = 2;
+    private ExclusiveWorkerFactory workerFactory;
+    private ThreadFactory threadFactory;
+    private ThreadPoolImpl pool;
+    
+    @Before
+    public void setUp() {
+        workerFactory = EasyMock.createMock(ExclusiveWorkerFactory.class);
+        threadFactory = EasyMock.createMock(ThreadFactory.class);
+        
+        pool = new ThreadPoolImpl(max, workerFactory, threadFactory);
+    }
+    
+    @Test
+    public void onTaskAddedShouldSetupThreadImmediatelyWhenThreadNumberBelowMax() {
+        Runnable worker = EasyMock.createMock(Runnable.class);
+        
+        EasyMock.expect(workerFactory.create(pool)).andReturn(worker);
+        EasyMock.replay(workerFactory);
+        
+        Thread thread = EasyMock.createMock(Thread.class);
+        thread.start();
+        EasyMock.replay(thread);
+        
+        EasyMock.expect(threadFactory.newThread(worker)).andReturn(thread);
+        EasyMock.replay(threadFactory);
+        
+        pool.onTaskAdded();
+        
+        assertEquals(1, pool.getThreadNumber());
+        assertEquals(0, pool.getRemainingTask());
+        EasyMock.verify(thread);
+    }
+    
+    @Test
+    public void onTaskAddedShouldSetupThreadImmediatelyUntilMaxThreadNumber() {
+        Runnable worker = EasyMock.createMock(Runnable.class);
+        
+        EasyMock.expect(workerFactory.create(pool)).andStubReturn(worker);
+        EasyMock.replay(workerFactory);
+        
+        Thread thread1 = EasyMock.createMock(Thread.class);
+        thread1.start();
+        EasyMock.replay(thread1);
+        
+        Thread thread2 = EasyMock.createMock(Thread.class);
+        thread2.start();
+        EasyMock.replay(thread2);
+        
+        EasyMock.expect(threadFactory.newThread(worker))
+                .andReturn(thread1)
+                .andReturn(thread2);
+        EasyMock.replay(threadFactory);
+        
+        pool.onTaskAdded();
+        pool.onTaskAdded();
+        pool.onTaskAdded();
+        
+        assertEquals(1, pool.getRemainingTask());
+        assertEquals(max, pool.getThreadNumber());
+        EasyMock.verify(thread1, thread2);
+    }
+
+    @Test
+    public void onFinishShouldDecreaseThreadNumber() {
+        Runnable worker = EasyMock.createMock(Runnable.class);
+        EasyMock.expect(workerFactory.create(pool)).andReturn(worker);
+        EasyMock.replay(workerFactory);
+        
+        Thread thread = EasyMock.createMock(Thread.class);        
+        EasyMock.expect(threadFactory.newThread(worker)).andReturn(thread);
+        EasyMock.replay(threadFactory);
+        
+        pool.onTaskAdded();
+        pool.onFinish();
+        
+        assertEquals(0, pool.getThreadNumber());
+    }
+    
+    @Test
+    public void onFinishShouldSetupThreadWhenTaskNotEmpty() {
+        Runnable worker = EasyMock.createMock(Runnable.class);
+        EasyMock.expect(workerFactory.create(pool)).andStubReturn(worker);
+        EasyMock.replay(workerFactory);
+        
+        Thread thread = EasyMock.createMock(Thread.class);
+        EasyMock.expect(threadFactory.newThread(worker)).andStubReturn(thread);
+        EasyMock.replay(threadFactory);
+        
+        pool.onTaskAdded();
+        pool.onTaskAdded();
+        pool.onTaskAdded();
+        pool.onTaskAdded();
+        
+        assertEquals(2, pool.getThreadNumber());
+        assertEquals(2, pool.getRemainingTask());
+        
+        pool.onFinish();
+        
+        assertEquals(2, pool.getThreadNumber());
+        assertEquals(1, pool.getRemainingTask());
+    }
+}


### PR DESCRIPTION
Due some limitation (like cancel, wait, shutdown, etc) and potential missused as ExecutorService, the design need to be downgraded as basic Executor only.